### PR TITLE
Fix getEntitiesByClass with EntityLink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /.php_cs.cache
 /composer.lock
+/.vscode/

--- a/src/Action.php
+++ b/src/Action.php
@@ -6,6 +6,8 @@ use Assert\Assertion;
 
 final class Action
 {
+    use SirenObject;
+
     /**
      * @var string
      */
@@ -15,11 +17,6 @@ final class Action
      * @var string
      */
     private $href;
-
-    /**
-     * @var string[]
-     */
-    private $classes;
 
     /**
      * @var string
@@ -94,19 +91,6 @@ final class Action
     public function getHref() : string
     {
         return $this->href;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getClasses() : array
-    {
-        return $this->classes;
-    }
-
-    public function hasClass(string $name) : bool
-    {
-        return in_array($name, $this->classes, true);
     }
 
     public function getMethod() : string

--- a/src/Action.php
+++ b/src/Action.php
@@ -24,11 +24,6 @@ final class Action
     private $method;
 
     /**
-     * @var string
-     */
-    private $title;
-
-    /**
      * @var Field[]
      */
     private $fields;
@@ -96,11 +91,6 @@ final class Action
     public function getMethod() : string
     {
         return $this->method;
-    }
-
-    public function getTitle() : string
-    {
-        return $this->title;
     }
 
     public function getFields() : array

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -8,10 +8,7 @@ use TomPHP\Siren\Exception\NotFound;
 
 final class Entity implements LinkProviderInterface, EntityRepresentation
 {
-    /**
-     * @var string[]
-     */
-    private $classes;
+    use SirenObject;
 
     /**
      * @var array
@@ -110,19 +107,6 @@ final class Entity implements LinkProviderInterface, EntityRepresentation
         $this->title      = $title;
         $this->actions    = $actions;
         $this->entities   = $entities;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getClasses() : array
-    {
-        return $this->classes;
-    }
-
-    public function hasClass(string $name) : bool
-    {
-        return in_array($name, $this->classes, true);
     }
 
     public function getProperties() : array

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -21,11 +21,6 @@ final class Entity implements LinkProviderInterface, EntityRepresentation
     private $links;
 
     /**
-     * @var string
-     */
-    private $title;
-
-    /**
      * @var Action[]
      */
     private $actions;
@@ -183,11 +178,6 @@ final class Entity implements LinkProviderInterface, EntityRepresentation
                 }
             )
         );
-    }
-
-    public function getTitle() : string
-    {
-        return $this->title;
     }
 
     /**

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -6,33 +6,57 @@ use Assert\Assertion;
 use Psr\Link\LinkProviderInterface;
 use TomPHP\Siren\Exception\NotFound;
 
-final class Entity implements LinkProviderInterface, EntityRepresentation
+class Entity implements LinkProviderInterface, EntityRepresentation
 {
     use SirenObject;
 
     /**
      * @var array
      */
-    private $properties;
+    protected $properties;
 
     /**
      * @var Link[]
      */
-    private $links;
+    protected $links;
 
     /**
      * @var Action[]
      */
-    private $actions;
+    protected $actions;
 
     /**
-     * @var EntityLink[]
+     * @var SubEntityRepresentation[]
      */
-    private $entities;
+    protected $entities;
 
     public static function builder() : EntityBuilder
     {
         return new EntityBuilder();
+    }
+
+    protected static function parseNestedObjects(array &$array)
+    {
+        if (isset($array['links'])) {
+            $array['links'] = array_map([Link::class, 'fromArray'], $array['links']);
+        }
+
+        if (isset($array['actions'])) {
+            $array['actions'] = array_map([Action::class, 'fromArray'], $array['actions']);
+        }
+
+        if (isset($array['entities'])) {
+            $array['entities'] = array_map(
+                function (array $entity) {
+                    if (array_key_exists('href', $entity)) {
+                        return EntityLink::fromArray($entity);
+                    }
+                    return SubEntity::fromArray($entity);
+                },
+                $array['entities']
+            );
+        }
+
     }
 
     /**
@@ -40,46 +64,24 @@ final class Entity implements LinkProviderInterface, EntityRepresentation
      */
     public static function fromArray(array $array) : EntityRepresentation
     {
-        $links = [];
-        if (isset($array['links'])) {
-            $links = array_map([Link::class, 'fromArray'], $array['links']);
-        }
-
-        $actions = [];
-        if (isset($array['actions'])) {
-            $actions = array_map([Action::class, 'fromArray'], $array['actions']);
-        }
-
-        $entities = [];
-        if (isset($array['entities'])) {
-            $entities = array_map(
-                function (array $entity) {
-                    if (array_key_exists('href', $entity)) {
-                        return EntityLink::fromArray($entity);
-                    }
-                    return self::fromArray($entity);
-                },
-                $array['entities']
-            );
-        }
-
+        self::parseNestedObjects($array);
         return new self(
             $array['class'] ?? [],
             $array['properties'] ?? [],
-            $links,
+            $array['links'] ?? [],
             $array['title'] ?? null,
-            $actions,
-            $entities
+            $array['actions'] ?? [],
+            $array['entities'] ?? []
         );
     }
 
     /**
-     * @param string[]               $classes
-     * @param array                  $properties
-     * @param Link[]                 $links
-     * @param string                 $title
-     * @param Action[]               $actions
-     * @param EntityRepresentation[] $entities
+     * @param string[]    $classes
+     * @param array       $properties
+     * @param Link[]      $links
+     * @param string      $title
+     * @param Action[]    $actions
+     * @param SubEntity[] $entities
      *
      * @internal
      */
@@ -94,7 +96,7 @@ final class Entity implements LinkProviderInterface, EntityRepresentation
         Assertion::allString($classes);
         Assertion::allIsInstanceOf($links, Link::class);
         Assertion::allIsInstanceOf($actions, Action::class);
-        Assertion::allIsInstanceOf($entities, EntityRepresentation::class);
+        Assertion::allIsInstanceOf($entities, SubEntityRepresentation::class);
 
         $this->classes    = array_unique($classes);
         $this->properties = $properties;
@@ -214,7 +216,7 @@ final class Entity implements LinkProviderInterface, EntityRepresentation
     }
 
     /**
-     * @return EntityRepresentation[]
+     * @return SubEntityRepresentation[]
      */
     public function getEntities() : array
     {
@@ -222,13 +224,13 @@ final class Entity implements LinkProviderInterface, EntityRepresentation
     }
 
     /**
-     * @EntityRepresentation[]
+     * @SubEntityRepresentation[]
      */
     public function getEntitiesByProperty(string $name, $value) : array
     {
         return array_values(array_filter(
             $this->entities,
-            function (EntityRepresentation $entity) use ($name, $value) {
+            function (SubEntityRepresentation $entity) use ($name, $value) {
                 try {
                     return $entity->getProperty($name) === $value;
                 } catch (NotFound $e) {
@@ -239,14 +241,27 @@ final class Entity implements LinkProviderInterface, EntityRepresentation
     }
 
     /**
-     * @EntityRepresentation[]
+     * @SubEntityRepresentation[]
      */
     public function getEntitiesByClass(string $name) : array
     {
         return array_values(array_filter(
             $this->entities,
-            function (EntityRepresentation $entity) use ($name) {
+            function ($entity) use ($name) {
                 return $entity->hasClass($name);
+            }
+        ));
+    }
+
+    /**
+     * @SubEntityRepresentation[]
+     */
+    public function getEntitiesByRel(string $rel) : array
+    {
+        return array_values(array_filter(
+            $this->entities,
+            function ($entity) use ($rel) {
+                return $entity->hasRel($rel);
             }
         ));
     }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -56,7 +56,6 @@ class Entity implements LinkProviderInterface, EntityRepresentation
                 $array['entities']
             );
         }
-
     }
 
     /**

--- a/src/EntityBuilder.php
+++ b/src/EntityBuilder.php
@@ -1,6 +1,5 @@
 <?php declare(strict_types=1);
 
-
 namespace TomPHP\Siren;
 
 use Assert\Assertion;

--- a/src/EntityBuilder.php
+++ b/src/EntityBuilder.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
+
 namespace TomPHP\Siren;
+
+use Assert\Assertion;
 
 final class EntityBuilder
 {
@@ -119,7 +122,7 @@ final class EntityBuilder
     /**
      * @return $this
      */
-    public function addSubEntity(EntityRepresentation $entity) : self
+    public function addSubEntity(SubEntityRepresentation $entity) : self
     {
         $this->subEntities[] = $entity;
 
@@ -129,6 +132,20 @@ final class EntityBuilder
     public function build() : Entity
     {
         return new Entity(
+            $this->classes,
+            $this->properties,
+            $this->links,
+            $this->title,
+            $this->actions,
+            $this->subEntities
+        );
+    }
+
+    public function buildSubEntity(array $rels) : SubEntity
+    {
+        Assertion::allString($rels);
+        return new SubEntity(
+            $rels,
             $this->classes,
             $this->properties,
             $this->links,

--- a/src/EntityLink.php
+++ b/src/EntityLink.php
@@ -4,15 +4,10 @@ namespace TomPHP\Siren;
 
 use Assert\Assertion;
 
-final class EntityLink implements EntityRepresentation
+final class EntityLink implements EntityRepresentation, SubEntityRepresentation
 {
-
     use SirenObject;
-
-    /**
-     * @var array
-     */
-    private $rel;
+    use HasRels;
 
     /**
      * @var string
@@ -39,18 +34,18 @@ final class EntityLink implements EntityRepresentation
     }
 
     /**
-     * @param string[] $rel
+     * @param string[] $rels
      * @param string   $href
      * @param string[] $class
      * @param string   $title
      * @param string   $type
      */
-    public function __construct(array $rel, string $href, array $classes = [], string $title = null, string $type = null)
+    public function __construct(array $rels, string $href, array $classes = [], string $title = null, string $type = null)
     {
-        Assertion::allString($rel);
+        Assertion::allString($rels);
         Assertion::allString($classes);
 
-        $this->rel     = $rel;
+        $this->rels    = $rels;
         $this->href    = $href;
         $this->classes = $classes;
         $this->title   = $title;
@@ -60,7 +55,7 @@ final class EntityLink implements EntityRepresentation
     public function toArray() : array
     {
         $result = [
-            'rel'  => $this->rel,
+            'rel'  => $this->rels,
             'href' => $this->href,
         ];
 

--- a/src/EntityLink.php
+++ b/src/EntityLink.php
@@ -6,6 +6,9 @@ use Assert\Assertion;
 
 final class EntityLink implements EntityRepresentation
 {
+
+    use SirenObject;
+
     /**
      * @var array
      */
@@ -15,11 +18,6 @@ final class EntityLink implements EntityRepresentation
      * @var string
      */
     private $href;
-
-    /**
-     * @var array
-     */
-    private $class;
 
     /**
      * @var string
@@ -52,16 +50,16 @@ final class EntityLink implements EntityRepresentation
      * @param string   $title
      * @param string   $type
      */
-    public function __construct(array $rel, string $href, array $class = [], string $title = null, string $type = null)
+    public function __construct(array $rel, string $href, array $classes = [], string $title = null, string $type = null)
     {
         Assertion::allString($rel);
-        Assertion::allString($class);
+        Assertion::allString($classes);
 
-        $this->rel   = $rel;
-        $this->href  = $href;
-        $this->class = $class;
-        $this->title = $title;
-        $this->type  = $type;
+        $this->rel     = $rel;
+        $this->href    = $href;
+        $this->classes = $classes;
+        $this->title   = $title;
+        $this->type    = $type;
     }
 
     public function toArray() : array
@@ -71,8 +69,8 @@ final class EntityLink implements EntityRepresentation
             'href' => $this->href,
         ];
 
-        if (count($this->class)) {
-            $result['class'] = $this->class;
+        if (count($this->classes)) {
+            $result['class'] = $this->classes;
         }
 
         if (!is_null($this->title)) {

--- a/src/EntityLink.php
+++ b/src/EntityLink.php
@@ -22,11 +22,6 @@ final class EntityLink implements EntityRepresentation
     /**
      * @var string
      */
-    private $title;
-
-    /**
-     * @var string
-     */
     private $type;
 
     /**

--- a/src/Field.php
+++ b/src/Field.php
@@ -4,15 +4,12 @@ namespace TomPHP\Siren;
 
 final class Field
 {
+    use SirenObject;
+
     /**
      * @var string
      */
     private $name;
-
-    /**
-     * @var string[]
-     */
-    private $classes;
 
     /**
      * @var string
@@ -26,11 +23,6 @@ final class Field
      * @var mixed
      */
     private $value;
-
-    /**
-     * @var string
-     */
-    private $title;
 
     public static function fromArray(array $array) : self
     {
@@ -71,14 +63,6 @@ final class Field
     }
 
     /**
-     * @return string[]
-     */
-    public function getClasses() : array
-    {
-        return $this->classes;
-    }
-
-    /**
      * @return string|null
      */
     public function getType()
@@ -92,14 +76,6 @@ final class Field
     public function getValue()
     {
         return $this->value;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getTitle()
-    {
-        return $this->title;
     }
 
     public function toArray() : array

--- a/src/HasRels.php
+++ b/src/HasRels.php
@@ -2,9 +2,9 @@
 
 namespace TomPHP\Siren;
 
-# Both Links and (Sub-)Entities have a $rel array.
-# Defines the relationship of the sub-entity to its parent, per Web Linking (RFC5988) and Link Relations.
-# MUST be a non-empty array of strings. Required.
+// Both Links and (Sub-)Entities have a $rel array.
+// Defines the relationship of the sub-entity to its parent, per Web Linking (RFC5988) and Link Relations.
+// MUST be a non-empty array of strings. Required.
 trait HasRels
 {
     /**

--- a/src/HasRels.php
+++ b/src/HasRels.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace TomPHP\Siren;
+
+# Both Links and (Sub-)Entities have a $rel array.
+# Defines the relationship of the sub-entity to its parent, per Web Linking (RFC5988) and Link Relations.
+# MUST be a non-empty array of strings. Required.
+trait HasRels
+{
+    /**
+     * @var string[]
+     */
+    protected $rels;
+
+    public function getRels() : array
+    {
+        return $this->rels;
+    }
+
+    public function hasRel(string $rel) : bool
+    {
+        return in_array($rel, $this->rels, true);
+    }
+}

--- a/src/Link.php
+++ b/src/Link.php
@@ -6,6 +6,8 @@ use Psr\Link\LinkInterface;
 
 final class Link implements LinkInterface
 {
+    use SirenObject;
+
     /**
      * @var string[]
      */
@@ -15,11 +17,6 @@ final class Link implements LinkInterface
      * @var string
      */
     private $href;
-
-    /**
-     * @var string[]
-     */
-    private $classes;
 
     /**
      * @var string
@@ -79,19 +76,6 @@ final class Link implements LinkInterface
     public function getHref() : string
     {
         return $this->href;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getClasses() : array
-    {
-        return $this->classes;
-    }
-
-    public function hasClass(string $class) : bool
-    {
-        return in_array($class, $this->classes, true);
     }
 
     public function getTitle() : string

--- a/src/Link.php
+++ b/src/Link.php
@@ -7,11 +7,7 @@ use Psr\Link\LinkInterface;
 final class Link implements LinkInterface
 {
     use SirenObject;
-
-    /**
-     * @var string[]
-     */
-    private $rels;
+    use HasRels;
 
     /**
      * @var string
@@ -56,16 +52,6 @@ final class Link implements LinkInterface
         $this->classes = $classes;
         $this->title   = $title;
         $this->type    = $type;
-    }
-
-    public function getRels() : array
-    {
-        return $this->rels;
-    }
-
-    public function hasRel(string $rel) : bool
-    {
-        return in_array($rel, $this->rels, true);
     }
 
     public function getHref() : string

--- a/src/Link.php
+++ b/src/Link.php
@@ -21,11 +21,6 @@ final class Link implements LinkInterface
     /**
      * @var string
      */
-    private $title;
-
-    /**
-     * @var string
-     */
     private $type;
 
     public static function fromArray(array $array)
@@ -76,11 +71,6 @@ final class Link implements LinkInterface
     public function getHref() : string
     {
         return $this->href;
-    }
-
-    public function getTitle() : string
-    {
-        return $this->title;
     }
 
     public function getType() : string

--- a/src/SirenObject.php
+++ b/src/SirenObject.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace TomPHP\Siren;
 
@@ -6,12 +6,12 @@ trait SirenObject {
     /**
      * @var string[]
      */
-    private $classes;
+    protected $classes;
 
     /**
      * @var string
      */
-    private $title;
+    protected $title;
 
     /**
      * @return string[]

--- a/src/SirenObject.php
+++ b/src/SirenObject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TomPHP\Siren;
+
+trait SirenObject {
+    /**
+     * @var string[]
+     */
+    private $classes;
+
+    /**
+     * @return string[]
+     */
+    public function getClasses() : array
+    {
+        return $this->classes;
+    }
+
+    public function hasClass(string $name) : bool
+    {
+        return in_array($name, $this->classes, true);
+    }
+}

--- a/src/SirenObject.php
+++ b/src/SirenObject.php
@@ -2,7 +2,8 @@
 
 namespace TomPHP\Siren;
 
-trait SirenObject {
+trait SirenObject
+{
     /**
      * @var string[]
      */

--- a/src/SirenObject.php
+++ b/src/SirenObject.php
@@ -9,6 +9,11 @@ trait SirenObject {
     private $classes;
 
     /**
+     * @var string
+     */
+    private $title;
+
+    /**
      * @return string[]
      */
     public function getClasses() : array
@@ -19,5 +24,10 @@ trait SirenObject {
     public function hasClass(string $name) : bool
     {
         return in_array($name, $this->classes, true);
+    }
+
+    public function getTitle() : ?string
+    {
+        return $this->title;
     }
 }

--- a/src/SubEntity.php
+++ b/src/SubEntity.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace TomPHP\Siren;
+
+use Assert\Assertion;
+
+# Just like a normal entity, but an embedded sub-entity will have rels, too
+final class SubEntity extends Entity implements SubEntityRepresentation
+{
+    use HasRels;
+
+    public static function fromArray(array $array) : EntityRepresentation
+    {
+        Entity::parseNestedObjects($array);
+
+        return new SubEntity(
+            $array['rel'],
+            $array['class'] ?? [],
+            $array['properties'] ?? [],
+            $array['links'] ?? [],
+            $array['title'] ?? null,
+            $array['actions'] ?? [],
+            $array['entities'] ?? []
+        );
+    }
+
+    public function toArray() : array
+    {
+        $result = parent::toArray();
+        $result['rel'] = $this->rels;
+        return $result;
+    }
+
+    /**
+     * @param string[]                  $classes
+     * @param array                     $properties
+     * @param Link[]                    $links
+     * @param string                    $title
+     * @param Action[]                  $actions
+     * @param SubEntityRepresentation[] $entities
+     * @param string[]                  $rels
+     *
+     * @internal
+     */
+    public function __construct(
+        array $rels,
+        array $classes,
+        array $properties,
+        array $links,
+        string $title = null,
+        array $actions = [],
+        array $entities = []
+    ) {
+        parent::__construct($classes, $properties, $links, $title, $actions, $entities);
+        $this->rels = $rels;
+    }
+}

--- a/src/SubEntity.php
+++ b/src/SubEntity.php
@@ -2,9 +2,7 @@
 
 namespace TomPHP\Siren;
 
-use Assert\Assertion;
-
-# Just like a normal entity, but an embedded sub-entity will have rels, too
+// Just like a normal entity, but an embedded sub-entity will have rels, too
 final class SubEntity extends Entity implements SubEntityRepresentation
 {
     use HasRels;
@@ -13,7 +11,7 @@ final class SubEntity extends Entity implements SubEntityRepresentation
     {
         Entity::parseNestedObjects($array);
 
-        return new SubEntity(
+        return new self(
             $array['rel'],
             $array['class'] ?? [],
             $array['properties'] ?? [],
@@ -26,7 +24,7 @@ final class SubEntity extends Entity implements SubEntityRepresentation
 
     public function toArray() : array
     {
-        $result = parent::toArray();
+        $result        = parent::toArray();
         $result['rel'] = $this->rels;
         return $result;
     }

--- a/src/SubEntityRepresentation.php
+++ b/src/SubEntityRepresentation.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace TomPHP\Siren;
+
+interface SubEntityRepresentation extends EntityRepresentation
+{
+    public function getRels() : array;
+    public function hasRel(string $rel) : bool;
+}

--- a/src/SubEntityRepresentation.php
+++ b/src/SubEntityRepresentation.php
@@ -1,9 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace TomPHP\Siren;
 
 interface SubEntityRepresentation extends EntityRepresentation
 {
     public function getRels() : array;
+
     public function hasRel(string $rel) : bool;
 }

--- a/tests/unit/EntityLinkTest.php
+++ b/tests/unit/EntityLinkTest.php
@@ -78,7 +78,7 @@ final class EntityLinkTest extends TestCase
     /** @test */
     public function on_hasClass_it_returns_true_if_present()
     {
-        $link = new EntityLink(['example-rel'], 'http://api.com/example', ["https://schema.org/Person"]);
-        assertTrue($link->hasClass("https://schema.org/Person"));
+        $link = new EntityLink(['example-rel'], 'http://api.com/example', ['https://schema.org/Person']);
+        assertTrue($link->hasClass('https://schema.org/Person'));
     }
 }

--- a/tests/unit/EntityLinkTest.php
+++ b/tests/unit/EntityLinkTest.php
@@ -74,4 +74,11 @@ final class EntityLinkTest extends TestCase
 
         assertEquals($link, EntityLink::fromArray($link->toArray()));
     }
+
+    /** @test */
+    public function on_hasClass_it_returns_true_if_present()
+    {
+        $link = new EntityLink(['example-rel'], 'http://api.com/example', ["https://schema.org/Person"]);
+        assertTrue($link->hasClass("https://schema.org/Person"));
+    }
 }

--- a/tests/unit/EntityTest.php
+++ b/tests/unit/EntityTest.php
@@ -357,7 +357,7 @@ final class EntityTest extends TestCase
     /** @test */
     public function on_getEntities_it_can_return_real_entities()
     {
-        $subEntity = Entity::builder()->buildSubEntity(["person"]);
+        $subEntity = Entity::builder()->buildSubEntity(['person']);
 
         $entity = Entity::builder()
             ->addSubEntity($subEntity)
@@ -388,8 +388,8 @@ final class EntityTest extends TestCase
     /** @test */
     public function on_getEntitiesByClass()
     {
-        $customer = Entity::builder()->addClass('customer')->buildSubEntity(["rel"]);
-        $product = Entity::builder()->addClass('product')->buildSubEntity(["rel"]);
+        $customer = Entity::builder()->addClass('customer')->buildSubEntity(['rel']);
+        $product  = Entity::builder()->addClass('product')->buildSubEntity(['rel']);
 
         $entity = Entity::builder()
             ->addSubEntity($customer)
@@ -403,7 +403,7 @@ final class EntityTest extends TestCase
     /** @test */
     public function on_getEntitiesByRel()
     {
-        $son = Entity::builder()->addClass('http://schema.org/Person')->buildSubEntity(['children']);
+        $son     = Entity::builder()->addClass('http://schema.org/Person')->buildSubEntity(['children']);
         $address = Entity::builder()->addClass('http://schema.org/PostalAddress')->buildSubEntity(['postalAddress']);
 
         $entity = Entity::builder()
@@ -418,7 +418,7 @@ final class EntityTest extends TestCase
     public function on_getEntitiesByClass_supports_EntityLink()
     {
         $customer = new EntityLink(['example-rel'], 'http://api.com/example', ['customer']);
-        $product = new EntityLink(['example-rel'], 'http://api.com/example', ['product']);
+        $product  = new EntityLink(['example-rel'], 'http://api.com/example', ['product']);
 
         $entity = Entity::builder()
             ->addSubEntity($customer)
@@ -527,7 +527,7 @@ final class EntityTest extends TestCase
             ->addSubEntity($subEntity)
             ->build();
 
-        $array = $entity->toArray();
+        $array  = $entity->toArray();
         $parsed = Entity::fromArray($array);
         assertEquals($entity, $parsed);
     }

--- a/tests/unit/EntityTest.php
+++ b/tests/unit/EntityTest.php
@@ -357,7 +357,7 @@ final class EntityTest extends TestCase
     /** @test */
     public function on_getEntities_it_can_return_real_entities()
     {
-        $subEntity = Entity::builder()->build();
+        $subEntity = Entity::builder()->buildSubEntity(["person"]);
 
         $entity = Entity::builder()
             ->addSubEntity($subEntity)
@@ -371,11 +371,11 @@ final class EntityTest extends TestCase
     {
         $tom = Entity::builder()
             ->addProperty('name', 'Tom')
-            ->build();
+            ->buildSubEntity(['participant']);
 
         $jerry = Entity::builder()
             ->addProperty('name', 'jerry')
-            ->build();
+            ->buildSubEntity(['participant']);
 
         $entity = Entity::builder()
             ->addSubEntity($tom)
@@ -388,15 +388,30 @@ final class EntityTest extends TestCase
     /** @test */
     public function on_getEntitiesByClass()
     {
-        $customer = Entity::builder()->addClass('customer')->build();
-        $product  = Entity::builder()->addClass('product')->build();
+        $customer = Entity::builder()->addClass('customer')->buildSubEntity(["rel"]);
+        $product = Entity::builder()->addClass('product')->buildSubEntity(["rel"]);
 
         $entity = Entity::builder()
             ->addSubEntity($customer)
             ->addSubEntity($product)
             ->build();
 
-        assertEquals([$product], $entity->getEntitiesByClass('product'));
+        $entities = $entity->getEntitiesByClass('product');
+        assertEquals([$product], $entities);
+    }
+
+    /** @test */
+    public function on_getEntitiesByRel()
+    {
+        $son = Entity::builder()->addClass('http://schema.org/Person')->buildSubEntity(['children']);
+        $address = Entity::builder()->addClass('http://schema.org/PostalAddress')->buildSubEntity(['postalAddress']);
+
+        $entity = Entity::builder()
+            ->addSubEntity($son)
+            ->addSubEntity($address)
+            ->build();
+
+        assertEquals([$address], $entity->getEntitiesByRel('postalAddress'));
     }
 
     /** @test */
@@ -495,12 +510,12 @@ final class EntityTest extends TestCase
     {
         $action = Action::builder()
             ->setName('add-customer')
-            ->setHref('http://api.com/cusotmer')
+            ->setHref('http://api.com/customer')
             ->setMethod('POST')
             ->build();
 
         $entityLink = new EntityLink(['example-rel'], 'http://api.com/example');
-        $subEntity  = Entity::builder()->build();
+        $subEntity  = Entity::builder()->buildSubEntity(['example-rel']);
 
         $entity = Entity::builder()
             ->addClass('example-class')
@@ -512,7 +527,9 @@ final class EntityTest extends TestCase
             ->addSubEntity($subEntity)
             ->build();
 
-        assertEquals($entity, Entity::fromArray($entity->toArray()));
+        $array = $entity->toArray();
+        $parsed = Entity::fromArray($array);
+        assertEquals($entity, $parsed);
     }
 
     /** @test */

--- a/tests/unit/EntityTest.php
+++ b/tests/unit/EntityTest.php
@@ -400,6 +400,20 @@ final class EntityTest extends TestCase
     }
 
     /** @test */
+    public function on_getEntitiesByClass_supports_EntityLink()
+    {
+        $customer = new EntityLink(['example-rel'], 'http://api.com/example', ['customer']);
+        $product = new EntityLink(['example-rel'], 'http://api.com/example', ['product']);
+
+        $entity = Entity::builder()
+            ->addSubEntity($customer)
+            ->addSubEntity($product)
+            ->build();
+
+        assertEquals([$product], $entity->getEntitiesByClass('product'));
+    }
+
+    /** @test */
     public function on_toArray_it_converts_to_an_array_for_minimal_values()
     {
         $entity = Entity::builder()


### PR DESCRIPTION
`Entity#entities` is annotated as `EntityLink[]` but that one didn't implement `hasClass`. By extracting the corresponding functionality into a trait, it works.

Note that I'm a total PHP-ignoramus - so if traits aren't the way to go or something along these lines, please let me know. Unfortunately I wasn't able to run the codestyle-fixer, as my PHP version was too recent for the RC version and the rule file incompatible with the released one. :sweat_smile: 